### PR TITLE
Avoid use of arg as a formal parameter for non-variadic functions.

### DIFF
--- a/gap/algebra.gi
+++ b/gap/algebra.gi
@@ -147,7 +147,7 @@ BindGlobal("TOTALDEGREE@", function(x)
     return d;
 end);
 
-BindGlobal("STRINGSTOLMACHINE@", function(r,arg,creator)
+BindGlobal("STRINGSTOLMACHINE@", function(r,args,creator)
     local temp, i, j, gens, transitions, output, data, Error;
 
     Error := function(arg)
@@ -157,12 +157,12 @@ BindGlobal("STRINGSTOLMACHINE@", function(r,arg,creator)
         CallFuncList(VALUE_GLOBAL("Error"),arg);
     end;
     
-    if not IsRing(r) or not ForAll(arg,IsString) then
-        Error("<arg> should contain a ring and strings\n");
+    if not IsRing(r) or not ForAll(args,IsString) then
+        Error("<args> should contain a ring and strings\n");
     fi;
-    temp := List(arg, x->SplitString(x,"="));
+    temp := List(args, x->SplitString(x,"="));
     if ForAny(temp,x->Size(x)<>2) then
-        Error("<arg> should have the form a=[[...]...]\n");
+        Error("<args> should have the form a=[[...]...]\n");
     fi;
     gens := List(temp, x->x[1]);
     if Size(Set(gens)) <> Size(gens) then

--- a/gap/group.gi
+++ b/gap/group.gi
@@ -1866,7 +1866,7 @@ end);
 BindGlobal("RANDOMNAME@", function()
     return List([1..10],i->Random("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
 end);
-BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, arg)
+BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, args)
     local temp, i, gens, states, action, mgens, data, Error, category, machine, group;
     
     Error := function(arg)
@@ -1876,18 +1876,18 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, arg)
         CallFuncList(VALUE_GLOBAL("Error"),arg);
     end;
     
-    if not IsString(arg[Length(arg)]) then
-        category := Remove(arg);
+    if not IsString(args[Length(args)]) then
+        category := Remove(args);
     else
         category := IsFRObject;
     fi;
     
-    if arg=[] or not ForAll(arg,IsString) then
+    if args=[] or not ForAll(args,IsString) then
         Error("<arg> should be a non-empty sequence of strings\n");
     fi;
-    temp := List(arg, x->SplitString(x,"="));
+    temp := List(args, x->SplitString(x,"="));
     if ForAny(temp,x->Size(x)<>2) then
-        Error("<arg> should have the form g=...\n");
+        Error("<args> should have the form g=...\n");
     fi;
     gens := List(temp, x->x[1]);
     if Size(Set(gens)) <> Size(gens) then
@@ -1926,7 +1926,7 @@ BindGlobal("STRING_GROUP@", function(freecreator, s_generator, creator, arg)
             Add(states,temp);
             data.degree := Maximum(data.degree,Size(temp));
         else
-            Error("<arg> should have the form g=<...\n");
+            Error("<args> should have the form g=<...\n");
         fi;
     od;
     


### PR DESCRIPTION
A new syntax extension planned for 4.8 changes the meaning of arg as the last formal parameter of a function with more than one argument. To minimise confusion it is now also an error to use arg as non-last formal parameter. This PR renames arg to args in a couple of places in fr to avoid running into problems with this.